### PR TITLE
Add PyHC Actions for PHEP 3 compliance and environment compatibility

### DIFF
--- a/.github/workflows/pyhc-actions.yml
+++ b/.github/workflows/pyhc-actions.yml
@@ -1,0 +1,30 @@
+name: PyHC Actions
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Run quarterly: Jan 1, Apr 1, Jul 1, Oct 1 at 3pm UTC (8am MST)
+    - cron: 0 15 1 1,4,7,10 *
+  workflow_dispatch:
+
+jobs:
+  phep3-compliance:
+    name: PHEP 3 Compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check PHEP 3 Compliance
+        uses: heliophysicsPy/pyhc-actions/phep3-compliance@v1
+
+  pyhc-env-compat:
+    name: PyHC Environment Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check PyHC Environment Compatibility
+        uses: heliophysicsPy/pyhc-actions/pyhc-env-compat@v1


### PR DESCRIPTION
Greetings again, pyRFU folks, Shawn from PyHC here!

This PR adds PyHC's standard GitHub Actions checks for PHEP 3 compliance and PyHC Environment compatibility. These actions are now being used by several core PyHC packages, including SunPy and PlasmaPy, to catch dependency support and environment compatibility issues early.

For pyRFU, these checks would guard against exactly the kind of versioning problem we recently opened in #37: an upper-bound dependency constraint that can block future PHEP 3 support requirements and create pressure on the broader PyHC Environment.

## Summary

This PR adds two GitHub Actions workflows from [heliophysicsPy/pyhc-actions](https://github.com/heliophysicsPy/pyhc-actions):

### 1. PHEP 3 Compliance Checker
Validates that the package meets [PHEP 3](https://github.com/heliophysicsPy/standards/blob/main/pheps/phep-0003.md) requirements:
- Python version support (36-month support window)
- Core Scientific Python package version support (24-month support window)
- New version adoption within 6 months of release
- Warnings on upper-bound constraints and exact version pins (core Scientific Python packages only)

### 2. PyHC Environment Compatibility Checker
Detects dependency conflicts with the [PyHC Environment](https://github.com/heliophysicsPy/pyhc-docker-environment) to ensure the package can be installed alongside other PyHC packages:
- Errors when conflicts are detected in base package
- Warns when conflicts are detected in optional dependency extras

## Trigger Schedule
Both workflows run on:
- Push/PR to master branch
- Quarterly schedule (Jan 1, Apr 1, Jul 1, Oct 1 at 3pm UTC)
- Manual trigger via workflow_dispatch

## Feedback
Please share any feedback about how I've implemented these. I want these checks to be _helpful_, not cumbersome.
